### PR TITLE
Changed baseUrl to publicPath

### DIFF
--- a/web/vue/vue.config.js
+++ b/web/vue/vue.config.js
@@ -15,5 +15,5 @@ module.exports = {
       ])
     ]
   },
-  baseUrl: ''
+  publicPath: ''
 }


### PR DESCRIPTION
As per deprecation information in https://github.com/vuejs/vue-cli/issues/5162 baseUrl should be changed to publicPath.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
